### PR TITLE
chore(ci): fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      separator: "-"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
Dependabot automatically creates PRs to update dependencies with known security issues. The PRs are created with branch names like `dependabot/go_modules/github.com/hashicorp/nomad-1.1.12`, which is problematic for our CI runner. We use the branch name directly as the tag when building the docker image, and `/` is not allowed in docker tags. As a result, our CI runner fails every CI build at the stage of trying to build a docker image.

```
$ docker build -t dsaidgovsg/registrywatcher-ui:tag/with/a/slash .
invalid argument "dsaidgovsg/registrywatcher-ui:tag/with/a/slash" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
$ docker build -t dsaidgovsg/registrywatcher-ui:tag_with-no-slash .
[+] Building 3.2s (4/4) FINISHED
...
```

Replace slashes with hyphens in the dependabot config to resolve this issue.

https://github.com/dependabot/dependabot-core/issues/396#issuecomment-1016163246